### PR TITLE
Handled empty and null conversation names

### DIFF
--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -103,6 +103,18 @@ public class ConversationServlet extends HttpServlet {
     User user = userStore.getUser(username);
 
     String conversationTitle = request.getParameter("conversationTitle");
+
+    if(conversationTitle == null){
+      response.sendRedirect("/conversations");
+      return;
+    }
+
+    if (conversationTitle.equals("")) {
+      request.setAttribute("error", "Please enter at least one letter or number");
+      request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
+      return;
+    }
+
     if (!conversationTitle.matches("[\\w*]*")) {
       request.setAttribute("error", "Please enter only letters and numbers.");
       request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);

--- a/src/test/java/codeu/controller/ConversationServletTest.java
+++ b/src/test/java/codeu/controller/ConversationServletTest.java
@@ -128,6 +128,47 @@ public class ConversationServletTest {
   }
 
   @Test
+  public void testDoPost_ConversationNameIsEmpty() throws IOException, ServletException {
+    Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("");
+    Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
+
+    User fakeUser =
+        new User(
+            UUID.randomUUID(),
+            "test_username",
+            "$2a$10$eDhncK/4cNH2KE.Y51AWpeL8/5znNBQLuAFlyJpSYNODR/SJQ/Fg6",
+            Instant.now());
+    Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
+
+    conversationServlet.doPost(mockRequest, mockResponse);
+
+    Mockito.verify(mockConversationStore, Mockito.never())
+        .addConversation(Mockito.any(Conversation.class));
+    Mockito.verify(mockRequest).setAttribute("error", "Please enter at least one letter or number");
+    Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+  }
+
+  @Test
+  public void testDoPost_ConversationNameIsNull() throws IOException, ServletException {
+    Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn(null);
+    Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
+
+    User fakeUser =
+        new User(
+            UUID.randomUUID(),
+            "test_username",
+            "$2a$10$eDhncK/4cNH2KE.Y51AWpeL8/5znNBQLuAFlyJpSYNODR/SJQ/Fg6",
+            Instant.now());
+    Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
+
+    conversationServlet.doPost(mockRequest, mockResponse);
+
+    Mockito.verify(mockConversationStore, Mockito.never())
+        .addConversation(Mockito.any(Conversation.class));
+    Mockito.verify(mockResponse).sendRedirect("/conversations");
+  }
+
+  @Test
   public void testDoPost_NewConversation() throws IOException, ServletException {
     Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");


### PR DESCRIPTION
I added tests for the above two cases as well. 
<img width="1440" alt="screen shot 2018-07-08 at 2 40 10 am" src="https://user-images.githubusercontent.com/25010539/42418728-ec82a45c-825a-11e8-9a36-c137229ab125.png">
