### PR TITLE
Allow users to create conversations with multi-word titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ in have access to only those two pages.
 * Nemo has an Activity Feed that allows users to see when new users join, create
  conversations, send messages, and update their About Me's.
 * Nemo has an dynamic search feature that allows users to search for other users. 
+* Nemo allows you to create conversations with titles that have multiple words.
 
 ## Step 1: Download Java
 

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -107,16 +107,7 @@ public class ChatServlet extends HttpServlet {
 
     String requestUrl = request.getRequestURI();
     String conversationIdAsString = requestUrl.substring("/chat/".length());
-    UUID conversationId = null;
-
-    try{
-      conversationId = UUID.fromString(conversationIdAsString);
-    }
-    catch(Exception e){
-      System.out.println("Conversation was null: " + conversationIdAsString);
-      response.sendRedirect("/conversations");
-      return;
-    }
+    UUID conversationId = getIdFromString(conversationIdAsString);
 
     Conversation conversation = conversationStore.getConversation(conversationId);
     if (conversation == null) {
@@ -152,16 +143,7 @@ public class ChatServlet extends HttpServlet {
 
     String requestUrl = request.getRequestURI();
     String conversationIdAsString = requestUrl.substring("/chat/".length());
-    UUID conversationId = null;
-
-    try{
-      conversationId = UUID.fromString(conversationIdAsString);
-    }
-    catch(Exception e){
-      System.out.println("Conversation was null: " + conversationIdAsString);
-      response.sendRedirect("/conversations");
-      return;
-    }
+    UUID conversationId = getIdFromString(conversationIdAsString);
 
     Conversation conversation = conversationStore.getConversation(conversationId);
     if (conversation == null) {
@@ -239,16 +221,7 @@ public class ChatServlet extends HttpServlet {
 
     String requestUrl = request.getRequestURI();
     String conversationIdAsString = requestUrl.substring("/chat/".length());
-    UUID conversationId = null;
-
-    try{
-      conversationId = UUID.fromString(conversationIdAsString);
-    }
-    catch(Exception e){
-      System.out.println("Conversation was null: " + conversationIdAsString);
-      response.sendRedirect("/conversations");
-      return;
-    }
+    UUID conversationId = getIdFromString(conversationIdAsString);
 
     Conversation conversation = conversationStore.getConversation(conversationId);
     if (conversation == null) {
@@ -319,5 +292,22 @@ public class ChatServlet extends HttpServlet {
       }
     }
     return false;
+  }
+
+  /*
+  * This function converts from string to UUID.
+  * Returns null if string is not a proper representation of UUID.
+  */
+  private UUID getIdFromString(String input) {
+    UUID conversationId = null;
+
+    try{
+      conversationId = UUID.fromString(input);
+    }
+    catch(Exception e){
+      return null;
+    }
+
+    return conversationId;
   }
 }

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -104,18 +104,27 @@ public class ChatServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response)
       throws IOException, ServletException {
-    String requestUrl = request.getRequestURI();
-    String conversationTitle = requestUrl.substring("/chat/".length());
 
-    Conversation conversation = conversationStore.getConversationWithTitle(conversationTitle);
-    if (conversation == null) {
-      // couldn't find conversation, redirect to conversation list
-      System.out.println("Conversation was null: " + conversationTitle);
+    String requestUrl = request.getRequestURI();
+    String conversationIdAsString = requestUrl.substring("/chat/".length());
+    UUID conversationId = null;
+
+    try{
+      conversationId = UUID.fromString(conversationIdAsString);
+    }
+    catch(Exception e){
+      System.out.println("Conversation was null: " + conversationIdAsString);
       response.sendRedirect("/conversations");
       return;
     }
 
-    UUID conversationId = conversation.getId();
+    Conversation conversation = conversationStore.getConversation(conversationId);
+    if (conversation == null) {
+      // couldn't find conversation, redirect to conversation list
+      System.out.println("Conversation was null: " + conversationIdAsString);
+      response.sendRedirect("/conversations");
+      return;
+    }
 
     List<Message> messages = messageStore.getMessagesInConversation(conversationId);
 
@@ -142,11 +151,22 @@ public class ChatServlet extends HttpServlet {
     User user = userStore.getUser(username);
 
     String requestUrl = request.getRequestURI();
-    String conversationTitle = requestUrl.substring("/chat/".length());
+    String conversationIdAsString = requestUrl.substring("/chat/".length());
+    UUID conversationId = null;
 
-    Conversation conversation = conversationStore.getConversationWithTitle(conversationTitle);
+    try{
+      conversationId = UUID.fromString(conversationIdAsString);
+    }
+    catch(Exception e){
+      System.out.println("Conversation was null: " + conversationIdAsString);
+      response.sendRedirect("/conversations");
+      return;
+    }
+
+    Conversation conversation = conversationStore.getConversation(conversationId);
     if (conversation == null) {
       // couldn't find conversation, redirect to conversation list
+      System.out.println("Conversation was null: " + conversationIdAsString);
       response.sendRedirect("/conversations");
       return;
     }
@@ -168,8 +188,9 @@ public class ChatServlet extends HttpServlet {
 
       List<String> messageInformation = new ArrayList<String>();
       messageInformation.add(user.getName());
-      messageInformation.add(conversationTitle);
+      messageInformation.add(conversation.getTitle());
       messageInformation.add(cleanedMessageContent);
+      messageInformation.add(conversationId.toString());
       Event messageEvent = 
           new Event(
               UUID.randomUUID(), 
@@ -194,7 +215,7 @@ public class ChatServlet extends HttpServlet {
 
         List<String> botMessageInformation = new ArrayList<String>();
         botMessageInformation.add("NemoBot");
-        botMessageInformation.add(conversationTitle);
+        botMessageInformation.add(conversation.getTitle());
         botMessageInformation.add(botResponse);
         Event botMessageEvent = 
             new Event(
@@ -207,7 +228,7 @@ public class ChatServlet extends HttpServlet {
     }
  
     // redirect to a GET request
-    response.sendRedirect("/chat/" + conversationTitle);
+    response.sendRedirect("/chat/" + conversationId);
   }
 
   @Override
@@ -217,11 +238,22 @@ public class ChatServlet extends HttpServlet {
     String username = (String) request.getSession().getAttribute("user");
 
     String requestUrl = request.getRequestURI();
-    String conversationTitle = requestUrl.substring("/chat/".length());
+    String conversationIdAsString = requestUrl.substring("/chat/".length());
+    UUID conversationId = null;
 
-    Conversation conversation = conversationStore.getConversationWithTitle(conversationTitle);
+    try{
+      conversationId = UUID.fromString(conversationIdAsString);
+    }
+    catch(Exception e){
+      System.out.println("Conversation was null: " + conversationIdAsString);
+      response.sendRedirect("/conversations");
+      return;
+    }
+
+    Conversation conversation = conversationStore.getConversation(conversationId);
     if (conversation == null) {
       // couldn't find conversation, redirect to conversation list
+      System.out.println("Conversation was null: " + conversationIdAsString);
       response.sendRedirect("/conversations");
       return;
     }

--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -29,6 +29,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Whitelist;
 
 /** Servlet class responsible for the conversations page. */
 public class ConversationServlet extends HttpServlet {
@@ -109,7 +111,7 @@ public class ConversationServlet extends HttpServlet {
       return;
     }
 
-    conversationTitle = conversationTitle.trim();
+    conversationTitle = Jsoup.clean(conversationTitle.trim(), Whitelist.none());
 
     if (conversationTitle.equals("")) {
       request.setAttribute("error", "Please enter at least one character");

--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -109,27 +109,31 @@ public class ConversationServlet extends HttpServlet {
       return;
     }
 
+    conversationTitle = conversationTitle.trim();
+
     if (conversationTitle.equals("")) {
       request.setAttribute("error", "Please enter at least one letter or number");
       request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
       return;
     }
 
-    if (!conversationTitle.matches("[\\w*]*")) {
+    if (!conversationTitle.matches("[\\w*\\s*]*")) {
       request.setAttribute("error", "Please enter only letters and numbers.");
       request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
       return;
     }
 
-    if (conversationStore.isTitleTaken(conversationTitle)) {
+    String conversationTitleStored = conversationTitle.replaceAll(" ", "-");
+
+    if (conversationStore.isTitleTaken(conversationTitleStored)) {
       // conversation title is already taken, just go into that conversation instead of creating a
       // new one
-      response.sendRedirect("/chat/" + conversationTitle);
+      response.sendRedirect("/chat/" + conversationTitleStored);
       return;
     }
 
     Conversation conversation =
-        new Conversation(UUID.randomUUID(), user.getId(), conversationTitle, Instant.now());
+        new Conversation(UUID.randomUUID(), user.getId(), conversationTitleStored, Instant.now());
     conversation.addMember(username);
 
     conversationStore.addConversation(conversation);
@@ -141,6 +145,6 @@ public class ConversationServlet extends HttpServlet {
         conversation.getCreationTime(), conversationInformation);
     eventStore.addEvent(conversationEvent);
     
-    response.sendRedirect("/chat/" + conversationTitle);
+    response.sendRedirect("/chat/" + conversationTitleStored);
   }
 }

--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -112,28 +112,13 @@ public class ConversationServlet extends HttpServlet {
     conversationTitle = conversationTitle.trim();
 
     if (conversationTitle.equals("")) {
-      request.setAttribute("error", "Please enter at least one letter or number");
+      request.setAttribute("error", "Please enter at least one character");
       request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
-      return;
-    }
-
-    if (!conversationTitle.matches("[\\w*\\s*]*")) {
-      request.setAttribute("error", "Please enter only letters and numbers.");
-      request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
-      return;
-    }
-
-    String conversationTitleStored = conversationTitle.replaceAll(" ", "-");
-
-    if (conversationStore.isTitleTaken(conversationTitleStored)) {
-      // conversation title is already taken, just go into that conversation instead of creating a
-      // new one
-      response.sendRedirect("/chat/" + conversationTitleStored);
       return;
     }
 
     Conversation conversation =
-        new Conversation(UUID.randomUUID(), user.getId(), conversationTitleStored, Instant.now());
+        new Conversation(UUID.randomUUID(), user.getId(), conversationTitle, Instant.now());
     conversation.addMember(username);
 
     conversationStore.addConversation(conversation);
@@ -141,10 +126,11 @@ public class ConversationServlet extends HttpServlet {
     List<String> conversationInformation = new ArrayList<>();
     conversationInformation.add(user.getName());
     conversationInformation.add(conversationTitle);
+    conversationInformation.add(conversation.getId().toString());
     Event conversationEvent = new Event(UUID.randomUUID(), "Conversation", 
         conversation.getCreationTime(), conversationInformation);
     eventStore.addEvent(conversationEvent);
     
-    response.sendRedirect("/chat/" + conversationTitleStored);
+    response.sendRedirect("/chat/" + conversation.getId());
   }
 }

--- a/src/main/java/codeu/model/store/basic/ConversationStore.java
+++ b/src/main/java/codeu/model/store/basic/ConversationStore.java
@@ -96,27 +96,6 @@ public class ConversationStore {
     persistentStorageAgent.writeThrough(conversation);
   }
 
-  /** Check whether a Conversation title is already known to the application. */
-  public boolean isTitleTaken(String title) {
-    // This approach will be pretty slow if we have many Conversations.
-    for (Conversation conversation : conversations) {
-      if (conversation.getTitle().equals(title)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /** Find and return the Conversation with the given title. */
-  public Conversation getConversationWithTitle(String title) {
-    for (Conversation conversation : conversations) {
-      if (conversation.getTitle().equals(title)) {
-        return conversation;
-      }
-    }
-    return null;
-  }
-
   /** Sets the List of Conversations stored by this ConversationStore. */
   public void setConversations(List<Conversation> conversations) {
     this.conversations = conversations;

--- a/src/main/webapp/WEB-INF/view/activityfeed.jsp
+++ b/src/main/webapp/WEB-INF/view/activityfeed.jsp
@@ -47,18 +47,20 @@ List<Event> events = (List<Event>) request.getAttribute("events");
           }
           else {
             String conversationTitle = information.get(1);
-              if (event.getType().equals("Conversation")) {
+              if (event.getType().equals("Conversation") && information.size() > 2) {
+                String conversationId = information.get(2);
               %>
                 <a href="/profile/<%= userName %>"><%= userName %></a> created a new conversation: 
-                <a href="/chat/<%= conversationTitle %>"><%= conversationTitle %></a>
+                <a href="/chat/<%= conversationId %>"><%= conversationTitle %></a>
           </li>
               <%
               }
-              else if (event.getType().equals("Message")) {
+              else if (event.getType().equals("Message") && information.size() > 3) {
                 String messageContent = information.get(2);
+                String conversationId = information.get(3);
               %>
                 <a href="/profile/<%= userName %>"><%= userName %></a> sent a message in 
-                <a href="/chat/<%= conversationTitle %>"><%= conversationTitle %></a>: "<%= messageContent %>"
+                <a href="/chat/<%= conversationId %>"><%= conversationTitle %></a>: "<%= messageContent %>"
           </li>
               <%
               }

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -50,7 +50,7 @@ String membersOfConversation = (String) request.getAttribute("membersOfConversat
     var newChatPrivacyValue = "<%= privacySettingButtonValue %>";
     $(document).ready(function() {
       $("#privacySettingButton").click(function() {
-        fetch('/chat/<%= conversation.getTitle() %>', {
+        fetch('/chat/<%= conversation.getId() %>', {
           method: "PUT",
           headers: {
             "purpose" : "Changing chat privacy"
@@ -128,7 +128,7 @@ String membersOfConversation = (String) request.getAttribute("membersOfConversat
       $('#addUsersModal').modal('hide');
       this.setAttribute('disabled', true);
 
-      fetch('/chat/<%= conversation.getTitle() %>', {
+      fetch('/chat/<%= conversation.getId() %>', {
           method: "PUT",
           headers: {
             "Content-Type": "application/json; charset=utf-8",
@@ -168,7 +168,7 @@ String membersOfConversation = (String) request.getAttribute("membersOfConversat
 
       <div class="titleAndSettings">
         <!-- Conversation title -->
-        <h1> <%= conversation.getTitle().replaceAll("-", " ") %> </h1>
+        <h1> <%= conversation.getTitle() %> </h1>
           
         <!-- Setting button and content -->
         <div class="dropdown">
@@ -208,7 +208,7 @@ String membersOfConversation = (String) request.getAttribute("membersOfConversat
     <hr/>
 
     <% if (request.getSession().getAttribute("user") != null) { %>
-    <form action="/chat/<%= conversation.getTitle() %>" method="POST">
+    <form action="/chat/<%= conversation.getId() %>" method="POST">
         <input type="text" name="message">
         <br/>
         <button type="submit">Send</button>

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -130,7 +130,7 @@ String privacySettingButtonValue = (Boolean) request.getAttribute("isPrivate")? 
 
       <div class="titleAndSettings">
         <!-- Conversation title -->
-        <h1> <%= conversation.getTitle() %> </h1>
+        <h1> <%= conversation.getTitle().replaceAll("-", " ") %> </h1>
           
         <!-- Setting button and content -->
         <div class="dropdown">

--- a/src/main/webapp/WEB-INF/view/conversations.jsp
+++ b/src/main/webapp/WEB-INF/view/conversations.jsp
@@ -60,8 +60,8 @@
     <%
       for(Conversation conversation : conversations){
     %>
-      <li><a href="/chat/<%= conversation.getTitle() %>">
-        <%= conversation.getTitle().replaceAll("-", " ")%></a></li>
+      <li><a href="/chat/<%= conversation.getId() %>">
+        <%= conversation.getTitle() %></a></li>
     <%
       }
     %>

--- a/src/main/webapp/WEB-INF/view/conversations.jsp
+++ b/src/main/webapp/WEB-INF/view/conversations.jsp
@@ -61,7 +61,7 @@
       for(Conversation conversation : conversations){
     %>
       <li><a href="/chat/<%= conversation.getTitle() %>">
-        <%= conversation.getTitle() %></a></li>
+        <%= conversation.getTitle().replaceAll("-", " ")%></a></li>
     <%
       }
     %>

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -91,16 +91,16 @@ public class ChatServletTest {
 
   @Test
   public void testDoGet() throws IOException, ServletException {
-    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
-
     UUID fakeConversationId = UUID.randomUUID();
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/" + fakeConversationId);
+
     Conversation fakeConversation =
         new Conversation(fakeConversationId, UUID.randomUUID(), "test_conversation", Instant.now());
     
     fakeConversation.addMember("test_user1");
     fakeConversation.addMember("test_user2");
 
-    Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
+    Mockito.when(mockConversationStore.getConversation(fakeConversationId))
         .thenReturn(fakeConversation);
 
     List<Message> fakeMessageList = new ArrayList<>();
@@ -126,9 +126,20 @@ public class ChatServletTest {
 
   @Test
   public void testDoGet_badConversation() throws IOException, ServletException {
-    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/bad_conversation");
-    Mockito.when(mockConversationStore.getConversationWithTitle("bad_conversation"))
+    UUID fakeConversationId = UUID.randomUUID();
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/" + fakeConversationId);
+    Mockito.when(mockConversationStore.getConversation(fakeConversationId))
         .thenReturn(null);
+
+    chatServlet.doGet(mockRequest, mockResponse);
+
+    Mockito.verify(mockResponse).sendRedirect("/conversations");
+  }
+
+  @Test
+  public void testDoGet_badUrl() throws IOException, ServletException {
+    UUID fakeConversationId = UUID.randomUUID();
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/does_not_resemble_UUID");
 
     chatServlet.doGet(mockRequest, mockResponse);
 
@@ -137,7 +148,8 @@ public class ChatServletTest {
   
   @Test
   public void testDoPost_ConversationNotFound() throws IOException, ServletException {
-    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
+    UUID fakeConversationId = UUID.randomUUID();
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/" + fakeConversationId);
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
     User fakeUser =
@@ -148,7 +160,7 @@ public class ChatServletTest {
             Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
-    Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
+    Mockito.when(mockConversationStore.getConversation(fakeConversationId))
         .thenReturn(null);
 
     chatServlet.doPost(mockRequest, mockResponse);
@@ -159,7 +171,8 @@ public class ChatServletTest {
 
   @Test
   public void testDoPost_MessageIsNull() throws IOException, ServletException {
-    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
+    UUID fakeConversationId = UUID.randomUUID();
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/" + fakeConversationId);
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
     User fakeUser =
@@ -171,8 +184,8 @@ public class ChatServletTest {
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
-    Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
+        new Conversation(fakeConversationId, UUID.randomUUID(), "test_conversation", Instant.now());
+    Mockito.when(mockConversationStore.getConversation(fakeConversationId))
         .thenReturn(fakeConversation);
 
     Mockito.when(mockRequest.getParameter("message")).thenReturn(null);
@@ -181,12 +194,13 @@ public class ChatServletTest {
 
     Mockito.verify(mockMessageStore, Mockito.never()).addMessage(Mockito.any(Message.class));
     Mockito.verify(mockEventStore, Mockito.never()).addEvent(Mockito.any(Event.class));
-    Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");
+    Mockito.verify(mockResponse).sendRedirect("/chat/" + fakeConversationId);
   }
 
   @Test
   public void testDoPost_StoresMessage() throws IOException, ServletException {
-    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
+    UUID fakeConversationId = UUID.randomUUID();
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/" + fakeConversationId);
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
     User fakeUser =
@@ -198,8 +212,8 @@ public class ChatServletTest {
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
-    Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
+        new Conversation(fakeConversationId, UUID.randomUUID(), "test_conversation", Instant.now());
+    Mockito.when(mockConversationStore.getConversation(fakeConversationId))
         .thenReturn(fakeConversation);
 
     Mockito.when(mockRequest.getParameter("message")).thenReturn("Test message.");
@@ -217,14 +231,16 @@ public class ChatServletTest {
     testInformation.add("test_username");
     testInformation.add("test_conversation");
     testInformation.add("Test message.");
+    testInformation.add(fakeConversationId.toString());
     Assert.assertEquals(testInformation, eventArgumentCaptor.getValue().getInformation());
 
-    Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");
+    Mockito.verify(mockResponse).sendRedirect("/chat/" + fakeConversationId);
   }
 
   @Test
   public void testDoPost_CleansHtmlContent() throws IOException, ServletException {
-    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
+    UUID fakeConversationId = UUID.randomUUID();
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/" + fakeConversationId);
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
     User fakeUser =
@@ -236,8 +252,8 @@ public class ChatServletTest {
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
-    Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
+        new Conversation(fakeConversationId, UUID.randomUUID(), "test_conversation", Instant.now());
+    Mockito.when(mockConversationStore.getConversation(fakeConversationId))
         .thenReturn(fakeConversation);
 
     Mockito.when(mockRequest.getParameter("message"))
@@ -257,17 +273,19 @@ public class ChatServletTest {
     testInformation.add("test_username");
     testInformation.add("test_conversation");
     testInformation.add("Contains html and  content.");
+    testInformation.add(fakeConversationId.toString());
     Assert.assertEquals(testInformation, eventArgumentCaptor.getValue().getInformation());
 
-    Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");
+    Mockito.verify(mockResponse).sendRedirect("/chat/" + fakeConversationId);
   }
 
   @Test
   public void testDoPut_makePublicPrivate() throws IOException, ServletException {
-    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
+    UUID fakeConversationId = UUID.randomUUID();
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/" + fakeConversationId);
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
     
-    Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
+    Mockito.when(mockConversationStore.getConversation(fakeConversationId))
         .thenReturn(mockConversation);
     Mockito.when(mockRequest.getHeader("purpose")).thenReturn("Changing chat privacy");
 
@@ -283,10 +301,11 @@ public class ChatServletTest {
 
   @Test
   public void testDoPut_makePrivatePublic() throws IOException, ServletException {
-    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
+    UUID fakeConversationId = UUID.randomUUID();
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/" + fakeConversationId);
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
     
-    Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
+    Mockito.when(mockConversationStore.getConversation(fakeConversationId))
         .thenReturn(mockConversation);
     Mockito.when(mockRequest.getHeader("purpose")).thenReturn("Changing chat privacy");
 
@@ -302,10 +321,11 @@ public class ChatServletTest {
 
   @Test
   public void testDoPut_addMembers() throws IOException, ServletException {
-    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
+    UUID fakeConversationId = UUID.randomUUID();
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/" + fakeConversationId);
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
     
-    Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
+    Mockito.when(mockConversationStore.getConversation(fakeConversationId))
         .thenReturn(mockConversation);
     Mockito.when(mockRequest.getHeader("purpose")).thenReturn("Adding users");
 

--- a/src/test/java/codeu/controller/ConversationServletTest.java
+++ b/src/test/java/codeu/controller/ConversationServletTest.java
@@ -85,49 +85,6 @@ public class ConversationServletTest {
   }
 
   @Test
-  public void testDoPost_BadConversationName() throws IOException, ServletException {
-    Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("bad !@#$% name");
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
-
-    User fakeUser =
-        new User(
-            UUID.randomUUID(),
-            "test_username",
-            "$2a$10$eDhncK/4cNH2KE.Y51AWpeL8/5znNBQLuAFlyJpSYNODR/SJQ/Fg6",
-            Instant.now());
-    Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
-
-    conversationServlet.doPost(mockRequest, mockResponse);
-
-    Mockito.verify(mockConversationStore, Mockito.never())
-        .addConversation(Mockito.any(Conversation.class));
-    Mockito.verify(mockRequest).setAttribute("error", "Please enter only letters and numbers.");
-    Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
-  }
-
-  @Test
-  public void testDoPost_ConversationNameTaken() throws IOException, ServletException {
-    Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("test_conversation");
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
-
-    User fakeUser =
-        new User(
-            UUID.randomUUID(),
-            "test_username",
-            "$2a$10$eDhncK/4cNH2KE.Y51AWpeL8/5znNBQLuAFlyJpSYNODR/SJQ/Fg6",
-            Instant.now());
-    Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
-
-    Mockito.when(mockConversationStore.isTitleTaken("test_conversation")).thenReturn(true);
-
-    conversationServlet.doPost(mockRequest, mockResponse);
-
-    Mockito.verify(mockConversationStore, Mockito.never())
-        .addConversation(Mockito.any(Conversation.class));
-    Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");
-  }
-
-  @Test
   public void testDoPost_ConversationNameIsEmpty() throws IOException, ServletException {
     Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
@@ -144,7 +101,7 @@ public class ConversationServletTest {
 
     Mockito.verify(mockConversationStore, Mockito.never())
         .addConversation(Mockito.any(Conversation.class));
-    Mockito.verify(mockRequest).setAttribute("error", "Please enter at least one letter or number");
+    Mockito.verify(mockRequest).setAttribute("error", "Please enter at least one character");
     Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
   }
 
@@ -181,8 +138,6 @@ public class ConversationServletTest {
             Instant.now());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
-    Mockito.when(mockConversationStore.isTitleTaken("test_conversation")).thenReturn(false);
-
     conversationServlet.doPost(mockRequest, mockResponse);
 
     ArgumentCaptor<Conversation> conversationArgumentCaptor =
@@ -201,8 +156,9 @@ public class ConversationServletTest {
     List<String> testInformation = new ArrayList<>();
     testInformation.add("test_username");
     testInformation.add("test_conversation");
+    testInformation.add(conversationArgumentCaptor.getValue().getId().toString());
     Assert.assertEquals(testInformation, eventArgumentCaptor.getValue().getInformation());
 
-    Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");
+    Mockito.verify(mockResponse).sendRedirect("/chat/" + conversationArgumentCaptor.getValue().getId());
   }
 }

--- a/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
@@ -31,42 +31,14 @@ public class ConversationStoreTest {
   }
 
   @Test
-  public void testGetConversationWithTitle_found() {
-    Conversation resultConversation =
-        conversationStore.getConversationWithTitle(CONVERSATION_ONE.getTitle());
-
-    assertEquals(CONVERSATION_ONE, resultConversation);
-  }
-
-  @Test
-  public void testGetConversationWithTitle_notFound() {
-    Conversation resultConversation = conversationStore.getConversationWithTitle("unfound_title");
-
-    Assert.assertNull(resultConversation);
-  }
-
-  @Test
-  public void testIsTitleTaken_true() {
-    boolean isTitleTaken = conversationStore.isTitleTaken(CONVERSATION_ONE.getTitle());
-
-    Assert.assertTrue(isTitleTaken);
-  }
-
-  @Test
-  public void testIsTitleTaken_false() {
-    boolean isTitleTaken = conversationStore.isTitleTaken("unfound_title");
-
-    Assert.assertFalse(isTitleTaken);
-  }
-
-  @Test
   public void testAddConversation() {
+    UUID inputConversationId = UUID.randomUUID();
     Conversation inputConversation =
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
+        new Conversation(inputConversationId, UUID.randomUUID(), "test_conversation", Instant.now());
 
     conversationStore.addConversation(inputConversation);
     Conversation resultConversation =
-        conversationStore.getConversationWithTitle("test_conversation");
+        conversationStore.getConversation(inputConversationId);
 
     assertEquals(inputConversation, resultConversation);
     Mockito.verify(mockPersistentStorageAgent).writeThrough(inputConversation);


### PR DESCRIPTION
resolves #85 

I encode spaces in the conversation title with "-" when stored in the conversation class. I replace them back with a space during display. I was going to do it the other way(replace the spaces with "-" when sending requests and putting them back after) but I thought this way would be easier and less riskier.

Also, I noticed we don't clean conversation titles for html like we do messages, is there a reason for that or should we add it?

EDIT

I switched to using UUIDs for the urls, I updated the tests and the Event information as well as removed some restrictions.