### PR TITLE
Can edit members of conversation(Add/remove users)

### DIFF
--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -268,6 +268,7 @@ public class ChatServlet extends HttpServlet {
 
       if(userNameArray == null || userNameArray.length == 0){
         response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.getWriter().write("Conversation must have at least one member.");
         return;
       }
 

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -115,6 +115,15 @@ public class ChatServlet extends HttpServlet {
       return;
     }
 
+    String purpose = request.getHeader("purpose");
+    if(purpose != null && purpose.equals("Get members")){
+      String json = new Gson().toJson(conversation.getMembers());
+      response.setContentType("application/json");
+      response.setCharacterEncoding("UTF-8");
+      response.getWriter().write(json);
+      return;
+    }
+
     UUID conversationId = conversation.getId();
 
     List<Message> messages = messageStore.getMessagesInConversation(conversationId);
@@ -243,7 +252,7 @@ public class ChatServlet extends HttpServlet {
       }
       conversationStore.updateConversation(conversation);
     }
-    else if(purpose.equals("Adding users")){
+    else if(purpose.equals("Setting users")){
 
       String jsonString = request.getReader().readLine();
       String cleanedJsonString = Jsoup.clean(jsonString, Whitelist.none());
@@ -257,6 +266,11 @@ public class ChatServlet extends HttpServlet {
         return;
       }
 
+      if(userNameArray == null || userNameArray.length == 0){
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        return;
+      }
+
       for(String user : userNameArray){
         if(userStore.getUser(user) == null){
           response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
@@ -264,14 +278,9 @@ public class ChatServlet extends HttpServlet {
         }
       }
 
-      HashSet<String> toBeAdded = new HashSet<>(Arrays.asList(userNameArray));
-      conversation.addMembers(toBeAdded);
+      HashSet<String> membersList = new HashSet<>(Arrays.asList(userNameArray));
+      conversation.setMembers(membersList);
       conversationStore.updateConversation(conversation);
-
-      String json = new Gson().toJson(conversation.getMembers());
-      response.setContentType("application/json");
-      response.setCharacterEncoding("UTF-8");
-      response.getWriter().write(json);
     }
     
   }

--- a/src/main/java/codeu/model/data/Conversation.java
+++ b/src/main/java/codeu/model/data/Conversation.java
@@ -93,6 +93,11 @@ public class Conversation {
     members.addAll(usernames);
   }
 
+  /** sets the members of this conversation. */
+  public void setMembers(HashSet<String> usernames) {
+    this.members = usernames;
+  }
+
   /** Returns the members of this conversation. */
   public HashSet<String> getMembers() {
     return members;

--- a/src/main/webapp/WEB-INF/view/addUserBox.jsp
+++ b/src/main/webapp/WEB-INF/view/addUserBox.jsp
@@ -1,9 +1,9 @@
 <!-- Modal -->
-<div class="modal fade" id="addUsersModal" tabindex="-1" role="dialog" aria-labelledby="addUsersModal" aria-hidden="true">
+<div class="modal fade" id="setUsersModal" tabindex="-1" role="dialog" aria-labelledby="setUsersModal" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="addUsersModalTitle">Add users to this conversation</h5>
+        <h5 class="modal-title" id="setUsersModalTitle">Edit the members of this conversation! </h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -20,7 +20,7 @@
         </ul>
       </div>
       <div class="modal-footer">
-        <button id="AddUsersModalCloseButton" type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
         <button disabled="true" id= "saveChangesButton" type="button" class="btn btn-primary">Save Changes</button>
       </div>
     </div>

--- a/src/main/webapp/WEB-INF/view/addUserBox.jsp
+++ b/src/main/webapp/WEB-INF/view/addUserBox.jsp
@@ -21,7 +21,7 @@
       </div>
       <div class="modal-footer">
         <button id="AddUsersModalCloseButton" type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-        <button disabled="true" id= "addSelectedUsersButton" type="button" class="btn btn-primary">Add users</button>
+        <button disabled="true" id= "saveChangesButton" type="button" class="btn btn-primary">Save Changes</button>
       </div>
     </div>
   </div>

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -99,9 +99,9 @@ String membersOfConversation = (String) request.getAttribute("membersOfConversat
         selectedUserList.appendChild(selectedUser);
     }
 
-    //prepopulate members of conversation in addUsers modal
+    //prepopulate members of conversation in setUsers modal
     $(document).ready(function(){
-      $("#modalOpenerButton").click(function(){
+      $("#EditMembersButton").click(function(){
 
         //clean up modal
         $('#userResult').empty();
@@ -188,7 +188,7 @@ String membersOfConversation = (String) request.getAttribute("membersOfConversat
     // save changes to the list of members
     $(document).on('click', '#saveChangesButton', function() {             
      
-      $('#addUsersModal').modal('hide');
+      $('#setUsersModal').modal('hide');
 
       fetch('/chat/<%= conversation.getTitle() %>', {
           method: "PUT",
@@ -235,7 +235,7 @@ String membersOfConversation = (String) request.getAttribute("membersOfConversat
           </button>
           <div class="dropdown-menu" aria-labelledby="dropdownMenu2">
             <button id="privacySettingButton" class="dropdown-item" type="button"><%= privacySettingButtonValue %></button>
-            <button id="modalOpenerButton" class="dropdown-item btn btn-primary" type="button" data-toggle="modal" data-target="#addUsersModal">Add Users</button>
+            <button id="EditMembersButton" class="dropdown-item btn btn-primary" type="button" data-toggle="modal" data-target="#setUsersModal">Edit Members</button>
           </div>
         </div>
       </div>

--- a/src/main/webapp/WEB-INF/view/searchbar.jsp
+++ b/src/main/webapp/WEB-INF/view/searchbar.jsp
@@ -22,21 +22,18 @@
                   a1.href = "/profile/" + userName;
                   a1.innerHTML = userName;
                   li.appendChild(a1);
+                  a2 = document.createElement("a");
+                  a2.innerHTML = "add";
+                  a2.setAttribute("class", "add-user-button");
+                  a2.setAttribute("username", userName);
 
-                  if(!membersOfConversation.has(userName)){
-                    a2 = document.createElement("a");
-                    a2.innerHTML = "add";
-                    a2.setAttribute("class", "add-user-button");
-                    a2.setAttribute("username", userName);
-
-                    if(ToBeAddedToConversation.has(userName)){
-                      a2.classList.add("isDisabled");
-                    }else{
-                      a2.href = "#";
-                    }
-                    li.appendChild(a2);
+                  if(membersAfterEditing.has(userName)){
+                    a2.classList.add("isDisabled");
+                  }else{
+                    a2.setAttribute("href", "#");
                   }
 
+                  li.appendChild(a2);
                   document.getElementById(putResultsIn).appendChild(li);
                 }
               } else {


### PR DESCRIPTION
At this point, any user can edit the members list by adding/removing any user they want as long as the list has atleast one member. Closing the modal, will discard any changes they didn't save and saving changes will update the list.

I was thinking of restricting this ability to only creators of conversation. what do you guys think?

resolves #98 