### PR TITLE
Access control 

### DIFF
--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -130,6 +130,13 @@ public class ChatServlet extends HttpServlet {
       return;
     }
 
+    String username = (String) request.getSession().getAttribute("user");
+    if(!conversation.containsMember(username)){
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      response.getWriter().write("You don't have access to this page");
+      return;
+    }
+
     String purpose = request.getHeader("purpose");
     if(purpose != null && purpose.equals("Get members")){
       String json = new Gson().toJson(conversation.getMembers());
@@ -172,6 +179,12 @@ public class ChatServlet extends HttpServlet {
       // couldn't find conversation, redirect to conversation list
       System.out.println("Conversation was null: " + conversationIdAsString);
       response.sendRedirect("/conversations");
+      return;
+    }
+
+    if(!conversation.containsMember(username)){
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      response.getWriter().write("You don't have access to this page");
       return;
     }
 
@@ -252,6 +265,12 @@ public class ChatServlet extends HttpServlet {
       // couldn't find conversation, redirect to conversation list
       System.out.println("Conversation was null: " + conversationIdAsString);
       response.sendRedirect("/conversations");
+      return;
+    }
+
+    if(!conversation.containsMember(username)){
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      response.getWriter().write("You don't have access to this page");
       return;
     }
 

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -132,8 +132,7 @@ public class ChatServlet extends HttpServlet {
 
     String username = (String) request.getSession().getAttribute("user");
     if(!conversation.containsMember(username)){
-      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-      response.getWriter().write("You don't have access to this page");
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "You don't have access to this page");
       return;
     }
 
@@ -183,8 +182,7 @@ public class ChatServlet extends HttpServlet {
     }
 
     if(!conversation.containsMember(username)){
-      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-      response.getWriter().write("You don't have access to this page");
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "You don't have access to this page");
       return;
     }
 
@@ -269,8 +267,7 @@ public class ChatServlet extends HttpServlet {
     }
 
     if(!conversation.containsMember(username)){
-      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-      response.getWriter().write("You don't have access to this page");
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "You don't have access to this page");
       return;
     }
 
@@ -301,19 +298,18 @@ public class ChatServlet extends HttpServlet {
         userNameArray = new Gson().fromJson(cleanedJsonString, String[].class);
       }
       catch(Exception e){
-        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unable to read json content.");
         return;
       }
 
       if(userNameArray == null || userNameArray.length == 0){
-        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-        response.getWriter().write("Conversation must have at least one member.");
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Conversation must have at least one member.");
         return;
       }
 
       for(String user : userNameArray){
         if(userStore.getUser(user) == null){
-          response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+          response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid json content");
           return;
         }
       }

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -72,10 +72,10 @@ public class PersistentDataStore {
         User user = new User(uuid, userName, passwordHash, creationTime);
         String aboutMe = (String) entity.getProperty("about_me");
         Boolean isAdmin = (Boolean) entity.getProperty("is_admin");
-        Instant lastSeenNotifications = Instant.parse((String) entity.getProperty("last_seen_notifications"));
+        String lastSeenNotifications = (String) entity.getProperty("last_seen_notifications");
         if(aboutMe != null) user.setAboutMe(aboutMe);
         if(isAdmin != null && isAdmin == true) user.setIsAdmin(isAdmin);
-        if (lastSeenNotifications!= null) user.setLastSeenNotifications(lastSeenNotifications);
+        if (lastSeenNotifications!= null) user.setLastSeenNotifications(Instant.parse(lastSeenNotifications));
         users.add(user);
       } catch (Exception e) {
         // In a production environment, errors should be very rare. Errors which may
@@ -209,7 +209,10 @@ public class PersistentDataStore {
     userEntity.setProperty("creation_time", user.getCreationTime().toString());
     userEntity.setProperty("about_me", user.getAboutMe());
     userEntity.setProperty("is_admin", user.getIsAdmin());
-    userEntity.setProperty("last_seen_notifications", user.getLastSeenNotifications().toString());
+    Instant last_seen_notifications = user.getLastSeenNotifications();
+    if(last_seen_notifications != null){
+      userEntity.setProperty("last_seen_notifications", last_seen_notifications.toString());
+    }
     datastore.put(userEntity);
   }
 

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -142,7 +142,7 @@ String membersOfConversation = (String) request.getAttribute("membersOfConversat
 
     // for make private/make public button
     var newChatPrivacyValue = "<%= privacySettingButtonValue %>";
-    $(document).ready(function()) {
+    $(document).ready(function() {
       $("#privacySettingButton").click(function() {
         fetch('/chat/<%= conversation.getId() %>', {
           method: "PUT",

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -118,8 +118,7 @@ String membersOfConversation = (String) request.getAttribute("membersOfConversat
           },
           credentials: "same-origin"
         }).then(function(response) {
-
-          if(!response.ok) {
+          if(response.status !== 200) {
             console.log("An error occured. Status code: " + response.status);
             return;
           }
@@ -198,11 +197,14 @@ String membersOfConversation = (String) request.getAttribute("membersOfConversat
           body: JSON.stringify(Array.from(membersAfterEditing)),
           credentials: "same-origin"
         }).then(function(response) {
-          if(!response.ok) {
+          if(response.status !== 200) {
             console.log("An error occured. Status code: " + response.status);
             return;
           }
           membersOfConversation = new Set(membersAfterEditing);
+          if(!membersOfConversation.has("<%= user %>")){
+            window.location.replace("/conversations");
+          }
         }, function(error) {
           console.log("An error occured. " + error.message);
         })

--- a/src/main/webapp/WEB-INF/view/conversations.jsp
+++ b/src/main/webapp/WEB-INF/view/conversations.jsp
@@ -59,6 +59,9 @@
       <ul class="mdl-list">
     <%
       for(Conversation conversation : conversations){
+        if(!conversation.containsMember(navBarUsername)){
+          continue;
+      }
     %>
       <li><a href="/chat/<%= conversation.getId() %>">
         <%= conversation.getTitle() %></a></li>

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -350,7 +350,6 @@ public class ChatServletTest {
     testInformation.add("test_username");
     testInformation.add("test_conversation");
     testInformation.add("Test message @NemoBot.");
-    System.out.println(testInformation.toString());
     // Assert.assertEquals(testInformation, eventArgumentCaptor.getValue().getInformation());
 
     NemoBot nemoBot = Mockito.mock(NemoBot.class);


### PR DESCRIPTION
Displayed only conversations a user is a member of and restricted access to conversations a user is not a member of.

If a user removes themselves from a chat, they will be redirected to the conversations page and will no longer be able to access said chat. This could be "leave group"  but let me know if you guys think this should be a seprate button or if I should add a pop up that says "are you sure you want to leave" or something like that.